### PR TITLE
[SDK][Ruby] Pass origin parameter on attach endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 0.2.0 - 2023-08-09
+
+- Add origin for SDK usage tracking
+
 ## 0.1.1 - 2023-02-02
 
 - Add verifying of webhook signature.
+
 ## 0.1.0 - 2023-01-25
 
 - Initial alpha release.

--- a/lib/paymongo/entities/payment_intent.rb
+++ b/lib/paymongo/entities/payment_intent.rb
@@ -32,7 +32,6 @@ module Paymongo
         @statement_descriptor = api_resource.attributes['statement_descriptor']
         @status = api_resource.attributes['status']
         @last_payment_error = api_resource.attributes['last_payment_error']
-        @origin = api_resource.attributes['origin']
         @payment_method_allowed = api_resource.attributes['payment_method_allowed']
         @payments = api_resource.attributes['payments'] #TODO: ENG-21218 PayMongo-Ruby - Map payments attribute to array of payment entities
         @next_action = next_action(api_resource.attributes['next_action'])

--- a/lib/paymongo/entities/payment_intent.rb
+++ b/lib/paymongo/entities/payment_intent.rb
@@ -32,6 +32,7 @@ module Paymongo
         @statement_descriptor = api_resource.attributes['statement_descriptor']
         @status = api_resource.attributes['status']
         @last_payment_error = api_resource.attributes['last_payment_error']
+        @origin = api_resource.attributes['origin']
         @payment_method_allowed = api_resource.attributes['payment_method_allowed']
         @payments = api_resource.attributes['payments'] #TODO: ENG-21218 PayMongo-Ruby - Map payments attribute to array of payment entities
         @next_action = next_action(api_resource.attributes['next_action'])

--- a/lib/paymongo/services/payment_intent.rb
+++ b/lib/paymongo/services/payment_intent.rb
@@ -3,13 +3,11 @@ module Paymongo
     URI = 'payment_intents'
 
     def self.attach(id, payload)
-      payload[:origin] = 'ruby'
-
       self.request(
         method: :post,
         object: Paymongo::Entities::PaymentIntent,
         path: "#{self::URI}/#{id}/attach",
-        payload: payload
+        payload: payload.merge(origin: 'ruby')
       )
     end
 

--- a/lib/paymongo/services/payment_intent.rb
+++ b/lib/paymongo/services/payment_intent.rb
@@ -3,6 +3,8 @@ module Paymongo
     URI = 'payment_intents'
 
     def self.attach(id, payload)
+      payload[:origin] = 'ruby'
+
       self.request(
         method: :post,
         object: Paymongo::Entities::PaymentIntent,

--- a/paymongo-ruby.gemspec
+++ b/paymongo-ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "paymongo-ruby"
-  s.version     = "0.1.1"
+  s.version     = "0.2.0"
   s.summary     = "PayMongo Ruby"
   s.description = "PayMongo Ruby Library"
   s.author      = "PayMongo"


### PR DESCRIPTION
What?
-

- Add origin parameter

Why?
-

- To track the usage of our SDK packages by passing origin as param.

Local Testing
-

<img width="1440" alt="image" src="https://github.com/paymongo/paymongo-ruby/assets/43851010/de3b526e-73ea-4b75-bc08-8e3c48a4c8b1">
<img width="1440" alt="image" src="https://github.com/paymongo/paymongo-ruby/assets/43851010/277c97e0-da24-47d7-a3d2-a5b2f2022652">



